### PR TITLE
Added missing category_rules api to PocketsmithClient class

### DIFF
--- a/pocketsmith/pocketsmith_client.py
+++ b/pocketsmith/pocketsmith_client.py
@@ -10,6 +10,7 @@ class PocketsmithClient:
         self.accounts = pocketsmith.AccountsApi(self.api_client)
         self.budgeting = pocketsmith.BudgetingApi(self.api_client)
         self.categories = pocketsmith.CategoriesApi(self.api_client)
+        self.category_rules = pocketsmith.CategoryRulesApi(self.api_client)                
         self.institutions = pocketsmith.InstitutionsApi(self.api_client)
         self.transaction_accounts = pocketsmith.TransactionAccountsApi(self.api_client)
         self.transactions = pocketsmith.TransactionsApi(self.api_client)


### PR DESCRIPTION
This change adds to the PocketsmithClient access to the category rules api. Allowing, among other things, the ability to query all the category rules defined by the user.