### PR TITLE
Updated __version__ to 1.1.0 

### DIFF
--- a/_overrides/pocketsmith_client.py
+++ b/_overrides/pocketsmith_client.py
@@ -8,8 +8,10 @@ class PocketsmithClient:
         self.api_client = pocketsmith.ApiClient(configuration)
 
         self.accounts = pocketsmith.AccountsApi(self.api_client)
+        self.attachments = pocketsmith.AttachmentsApi(self.api_client)
         self.budgeting = pocketsmith.BudgetingApi(self.api_client)
         self.categories = pocketsmith.CategoriesApi(self.api_client)
+        self.category_rules = pocketsmith.CategoryRulesApi(self.api_client)                
         self.institutions = pocketsmith.InstitutionsApi(self.api_client)
         self.transaction_accounts = pocketsmith.TransactionAccountsApi(self.api_client)
         self.transactions = pocketsmith.TransactionsApi(self.api_client)

--- a/generate-pocketsmith-library.sh
+++ b/generate-pocketsmith-library.sh
@@ -10,7 +10,8 @@ openapi-generator-cli generate \
   --generator-name python \
   --output ./build/pocketsmith \
   --package-name pocketsmith \
-  --verbose
+  --verbose \
+  --additional-properties=packageVersion=1.1.0
 
 rsync --archive --progress ./build/pocketsmith/pocketsmith/ ./pocketsmith
 rm -rf ./build/pocketsmith

--- a/pocketsmith/__init__.py
+++ b/pocketsmith/__init__.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 # import apis into sdk package
 from pocketsmith.api.accounts_api import AccountsApi

--- a/pocketsmith/api/budgeting_api.py
+++ b/pocketsmith/api/budgeting_api.py
@@ -211,7 +211,7 @@ class BudgetingApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :return: list[BudgetAnalysisPackage]
+        :return: BudgetAnalysisPackage
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -244,7 +244,7 @@ class BudgetingApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :return: tuple(list[BudgetAnalysisPackage], status_code(int), headers(HTTPHeaderDict))
+        :return: tuple(BudgetAnalysisPackage, status_code(int), headers(HTTPHeaderDict))
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -347,7 +347,7 @@ class BudgetingApi(object):
             body=body_params,
             post_params=form_params,
             files=local_var_files,
-            response_type='list[BudgetAnalysisPackage]',  # noqa: E501
+            response_type='BudgetAnalysisPackage',  # noqa: E501
             auth_settings=auth_settings,
             async_req=local_var_params.get('async_req'),
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501

--- a/pocketsmith/api_client.py
+++ b/pocketsmith/api_client.py
@@ -79,7 +79,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Generator/1.0.0/python'
+        self.user_agent = 'OpenAPI-Generator/1.1.0/python'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/pocketsmith/configuration.py
+++ b/pocketsmith/configuration.py
@@ -363,7 +363,7 @@ conf = pocketsmith.Configuration(
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 2.0\n"\
-               "SDK Package Version: 1.0.0".\
+               "SDK Package Version: 1.1.0".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):

--- a/pocketsmith/models/budget_analysis.py
+++ b/pocketsmith/models/budget_analysis.py
@@ -37,6 +37,7 @@ class BudgetAnalysis(object):
         'average_actual_amount': 'float',
         'average_forecast_amount': 'float',
         'end_date': 'date',
+        'currency_code': 'str',
         'periods': 'list[Period]',
         'start_date': 'date',
         'total_actual_amount': 'float',
@@ -49,6 +50,7 @@ class BudgetAnalysis(object):
         'average_actual_amount': 'average_actual_amount',
         'average_forecast_amount': 'average_forecast_amount',
         'end_date': 'end_date',
+        'currency_code': 'currency_code',
         'periods': 'periods',
         'start_date': 'start_date',
         'total_actual_amount': 'total_actual_amount',
@@ -57,7 +59,7 @@ class BudgetAnalysis(object):
         'total_under_by': 'total_under_by'
     }
 
-    def __init__(self, average_actual_amount=None, average_forecast_amount=None, end_date=None, periods=None, start_date=None, total_actual_amount=None, total_forecast_amount=None, total_over_by=None, total_under_by=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, average_actual_amount=None, average_forecast_amount=None, end_date=None, currency_code=None, periods=None, start_date=None, total_actual_amount=None, total_forecast_amount=None, total_over_by=None, total_under_by=None, local_vars_configuration=None):  # noqa: E501
         """BudgetAnalysis - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -66,6 +68,7 @@ class BudgetAnalysis(object):
         self._average_actual_amount = None
         self._average_forecast_amount = None
         self._end_date = None
+        self._currency_code = None
         self._periods = None
         self._start_date = None
         self._total_actual_amount = None
@@ -80,6 +83,8 @@ class BudgetAnalysis(object):
             self.average_forecast_amount = average_forecast_amount
         if end_date is not None:
             self.end_date = end_date
+        if currency_code is not None:
+            self.currency_code = currency_code
         if periods is not None:
             self.periods = periods
         if start_date is not None:
@@ -161,6 +166,29 @@ class BudgetAnalysis(object):
         """
 
         self._end_date = end_date
+
+    @property
+    def currency_code(self):
+        """Gets the currency_code of this BudgetAnalysis.  # noqa: E501
+
+        The currency code for this BudgetAnalysis.  # noqa: E501
+
+        :return: The currency_code of this BudgetAnalysis.  # noqa: E501
+        :rtype: str
+        """
+        return self._currency_code
+
+    @currency_code.setter
+    def currency_code(self, currency_code):
+        """Sets the currency_code of this BudgetAnalysis.
+
+        The currency code for this BudgetAnalysis.  # noqa: E501
+
+        :param currency_code: The currency_code of this BudgetAnalysis.  # noqa: E501
+        :type: str
+        """
+
+        self._currency_code = currency_code
 
     @property
     def periods(self):

--- a/pocketsmith/models/period.py
+++ b/pocketsmith/models/period.py
@@ -37,6 +37,7 @@ class Period(object):
         'actual_amount': 'float',
         'current': 'bool',
         'end_date': 'date',
+        'currency_code': 'str',
         'forecast_amount': 'float',
         'over_budget': 'bool',
         'over_by': 'float',
@@ -51,6 +52,7 @@ class Period(object):
         'actual_amount': 'actual_amount',
         'current': 'current',
         'end_date': 'end_date',
+        'currency_code': 'currency_code',
         'forecast_amount': 'forecast_amount',
         'over_budget': 'over_budget',
         'over_by': 'over_by',
@@ -61,7 +63,7 @@ class Period(object):
         'under_by': 'under_by'
     }
 
-    def __init__(self, actual_amount=None, current=None, end_date=None, forecast_amount=None, over_budget=None, over_by=None, percentage_used=None, refund_amount=None, start_date=None, under_budget=None, under_by=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, actual_amount=None, current=None, end_date=None, currency_code=None, forecast_amount=None, over_budget=None, over_by=None, percentage_used=None, refund_amount=None, start_date=None, under_budget=None, under_by=None, local_vars_configuration=None):  # noqa: E501
         """Period - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -70,6 +72,7 @@ class Period(object):
         self._actual_amount = None
         self._current = None
         self._end_date = None
+        self._currency_code = None
         self._forecast_amount = None
         self._over_budget = None
         self._over_by = None
@@ -86,6 +89,8 @@ class Period(object):
             self.current = current
         if end_date is not None:
             self.end_date = end_date
+        if currency_code is not None:
+            self.currency_code = currency_code
         if forecast_amount is not None:
             self.forecast_amount = forecast_amount
         if over_budget is not None:
@@ -171,6 +176,29 @@ class Period(object):
         """
 
         self._end_date = end_date
+
+    @property
+    def currency_code(self):
+        """Gets the currency_code of this Period.  # noqa: E501
+
+        The currency code for amounts in this Period.  # noqa: E501
+
+        :return: The currency_code of this Period.  # noqa: E501
+        :rtype: str
+        """
+        return self._currency_code
+
+    @currency_code.setter
+    def currency_code(self, currency_code):
+        """Sets the currency_code of this Period.
+
+        The currency code for amounts in this Period.  # noqa: E501
+
+        :param currency_code: The currency_code of this Period.  # noqa: E501
+        :type: str
+        """
+
+        self._currency_code = currency_code
 
     @property
     def forecast_amount(self):

--- a/pocketsmith/models/period.py
+++ b/pocketsmith/models/period.py
@@ -41,7 +41,7 @@ class Period(object):
         'over_budget': 'bool',
         'over_by': 'float',
         'percentage_used': 'float',
-        'refund_amound': 'float',
+        'refund_amount': 'float',
         'start_date': 'date',
         'under_budget': 'bool',
         'under_by': 'float'
@@ -55,13 +55,13 @@ class Period(object):
         'over_budget': 'over_budget',
         'over_by': 'over_by',
         'percentage_used': 'percentage_used',
-        'refund_amound': 'refund_amound',
+        'refund_amount': 'refund_amount',
         'start_date': 'start_date',
         'under_budget': 'under_budget',
         'under_by': 'under_by'
     }
 
-    def __init__(self, actual_amount=None, current=None, end_date=None, forecast_amount=None, over_budget=None, over_by=None, percentage_used=None, refund_amound=None, start_date=None, under_budget=None, under_by=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, actual_amount=None, current=None, end_date=None, forecast_amount=None, over_budget=None, over_by=None, percentage_used=None, refund_amount=None, start_date=None, under_budget=None, under_by=None, local_vars_configuration=None):  # noqa: E501
         """Period - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -74,7 +74,7 @@ class Period(object):
         self._over_budget = None
         self._over_by = None
         self._percentage_used = None
-        self._refund_amound = None
+        self._refund_amount = None
         self._start_date = None
         self._under_budget = None
         self._under_by = None
@@ -94,8 +94,8 @@ class Period(object):
             self.over_by = over_by
         if percentage_used is not None:
             self.percentage_used = percentage_used
-        if refund_amound is not None:
-            self.refund_amound = refund_amound
+        if refund_amount is not None:
+            self.refund_amount = refund_amount
         if start_date is not None:
             self.start_date = start_date
         if under_budget is not None:
@@ -265,27 +265,27 @@ class Period(object):
         self._percentage_used = percentage_used
 
     @property
-    def refund_amound(self):
-        """Gets the refund_amound of this Period.  # noqa: E501
+    def refund_amount(self):
+        """Gets the refund_amount of this Period.  # noqa: E501
 
         This attribute tracks the amount that has been refunded or deducted to the actual amount. When a category is set to \"always expense\", any credit transactions are treated as refunds and when set to \"always income\", any debit transactions are treated as deductions.  # noqa: E501
 
-        :return: The refund_amound of this Period.  # noqa: E501
+        :return: The refund_amount of this Period.  # noqa: E501
         :rtype: float
         """
-        return self._refund_amound
+        return self._refund_amount
 
-    @refund_amound.setter
-    def refund_amound(self, refund_amound):
-        """Sets the refund_amound of this Period.
+    @refund_amount.setter
+    def refund_amount(self, refund_amount):
+        """Sets the refund_amount of this Period.
 
         This attribute tracks the amount that has been refunded or deducted to the actual amount. When a category is set to \"always expense\", any credit transactions are treated as refunds and when set to \"always income\", any debit transactions are treated as deductions.  # noqa: E501
 
-        :param refund_amound: The refund_amound of this Period.  # noqa: E501
+        :param refund_amount: The refund_amount of this Period.  # noqa: E501
         :type: float
         """
 
-        self._refund_amound = refund_amound
+        self._refund_amount = refund_amount
 
     @property
     def start_date(self):

--- a/pocketsmith/pocketsmith_client.py
+++ b/pocketsmith/pocketsmith_client.py
@@ -10,6 +10,7 @@ class PocketsmithClient:
         self.accounts = pocketsmith.AccountsApi(self.api_client)
         self.budgeting = pocketsmith.BudgetingApi(self.api_client)
         self.categories = pocketsmith.CategoriesApi(self.api_client)
+        self.category_rules = pocketsmith.CategoryRulesApi(self.api_client)                
         self.institutions = pocketsmith.InstitutionsApi(self.api_client)
         self.transaction_accounts = pocketsmith.TransactionAccountsApi(self.api_client)
         self.transactions = pocketsmith.TransactionsApi(self.api_client)


### PR DESCRIPTION
To update __version__ I added the packageVersion=1.1.0 to the openapi-generator-cli call.

I moved changes to ./pocketsmith/pocketsmith_client.py upstream to ./_overrides, where ./generate_pocketsmith_client.sh copies the client source code from.

I re-generated the client with several fixes that are dependant on the pull request to the openapi spec here: https://github.com/theY4Kman/pocketsmith-api-spec/pull/2

- client.budgeting.get_trend_analysis() now works after correcting the opanAPI specification.
Added packageVerrsion=1.1.0 directive to openapi-generator-cli to bake the version into the source code. Now pocketsmith.__version__ returns 1.1.0
- Added currency_code field support to BudgetAnalysis and Period types.
- Fixed refund_amount field.